### PR TITLE
Support for setting the editor value. Support for multiple editors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ $ npm install vue-bulma-brace --save
       :codefolding="'markbegin'"
       :softwrap="'free'"
       :selectionstyle="'text'"
-      :highlightline="true">
+      :highlightline="true"
+      @code-change="codeChange"
+      ref="editor">
     </brace>
   </div>
 </template>
@@ -32,6 +34,15 @@ import Brace from 'vue-bulma-brace'
 export default {
   components: {
     Brace
+  },
+  mounted () {
+    // Set the initial value
+    this.$refs.editor.setCode("// the initial value")
+  },
+  methods: {
+    codeChange (newValue) {
+      // Use the value
+    }
   }
 }
 </script>

--- a/src/Brace.vue
+++ b/src/Brace.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id='vue-bulma-editor'></div>
+  <div :id='id'></div>
 </template>
 
 <script>
@@ -17,6 +17,10 @@ const regMap = {
 
 export default {
   props: {
+    id: {
+      type: String,
+      default: 'vue-bulma-editor'
+    },
     mode: {
       type: String,
       default: 'json',
@@ -79,7 +83,7 @@ export default {
   },
 
   mounted () {
-    editor = brace.edit('vue-bulma-editor')
+    editor = brace.edit(this.id)
     this.setMode()
     this.setTheme()
     editor.$blockScrolling = Infinity

--- a/src/Brace.vue
+++ b/src/Brace.vue
@@ -77,6 +77,9 @@ export default {
         editor.setTheme(themeObj.theme)
       }
     },
+    setCode (code) {
+        editor.session.setValue(code);
+    },
     emitCode () {
       this.$emit('code-change', editor.getValue())
     }


### PR DESCRIPTION
Added a simple method to set the code value using a 'ref' reference. Updated the examples accordingly.

I built this on top of another pull request (https://github.com/vue-bulma/brace/pull/5) from @marekkaczkowski to allow support for multiple editor instances.