### PR TITLE
emit selection change and add prop to set editor content

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ $ npm install vue-bulma-brace --save
       :codefolding="'markbegin'"
       :softwrap="'free'"
       :selectionstyle="'text'"
-      :highlightline="true">
+      :highlightline="true"
+      :editorValue="Hello World!">
     </brace>
   </div>
 </template>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install vue-bulma-brace --save
       :softwrap="'free'"
       :selectionstyle="'text'"
       :highlightline="true"
-      :editorValue="Hello World!">
+      :editorValue="'Hello World!'">
     </brace>
   </div>
 </template>

--- a/src/Brace.vue
+++ b/src/Brace.vue
@@ -75,6 +75,10 @@ export default {
     },
     emitCode () {
       this.$emit('code-change', editor.getValue())
+    },
+    emitSelection () {
+      let value = editor.session.getTextRange(editor.getSelectionRange())
+      this.$emit('selection-change', value)
     }
   },
 
@@ -84,6 +88,7 @@ export default {
     this.setTheme()
     editor.$blockScrolling = Infinity
     editor.getSession().on('change', this.emitCode)
+    editor.getSession().selection.on('changeSelection', this.emitSelection)
   },
 
   watch: {

--- a/src/Brace.vue
+++ b/src/Brace.vue
@@ -52,6 +52,10 @@ export default {
     highlightline: {
       type: Boolean,
       default: true
+    },
+    initialValue: {
+      type: String,
+      default: ''
     }
     // todo a lot of other things...
   },
@@ -89,6 +93,7 @@ export default {
     editor.$blockScrolling = Infinity
     editor.getSession().on('change', this.emitCode)
     editor.getSession().selection.on('changeSelection', this.emitSelection)
+    editor.setValue(this.initialValue)
   },
 
   watch: {

--- a/src/Brace.vue
+++ b/src/Brace.vue
@@ -53,7 +53,7 @@ export default {
       type: Boolean,
       default: true
     },
-    initialValue: {
+    editorValue: {
       type: String,
       default: ''
     }
@@ -93,7 +93,7 @@ export default {
     editor.$blockScrolling = Infinity
     editor.getSession().on('change', this.emitCode)
     editor.getSession().selection.on('changeSelection', this.emitSelection)
-    editor.setValue(this.initialValue)
+    editor.setValue(this.editorValue)
   },
 
   watch: {
@@ -118,6 +118,9 @@ export default {
     },
     highlightline (newVal) {
       editor.setHighlightActiveLine(newVal)
+    },
+    editorValue (newVal) {
+      editor.setValue(newVal)
     }
   }
 }


### PR DESCRIPTION
Added a vueJS event ("selection-change") when selection is changed, so that we can know what's selected and use only the selected content.
Added an editorValue prop to change editor content from the outside, changed the README accordingly to notify such possibility.